### PR TITLE
feat(example): one move per tick

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Example providing HID over GATT (HoG) profile for BLE on ESP using the ESP-IDF
 GATT Service Table APIs.
 
-https://github.com/finger563/esp-hid-service-table/assets/213467/3161d2a4-de4c-4f7d-8694-82c77d935254
+https://github.com/finger563/esp-hid-service-table/assets/213467/f972932c-6285-44ac-a576-f49e8d22fc9b
 
 ## Implementation
 
@@ -55,4 +55,4 @@ See the Getting Started Guide for full steps to configure and use ESP-IDF to bui
 
 ## Output
 
-![CleanShot 2023-10-06 at 14 17 54](https://github.com/finger563/esp-hid-service-table/assets/213467/37ae9a23-2d4e-4ab1-917b-5496e96bcac8)
+![CleanShot 2023-10-06 at 16 06 58](https://github.com/finger563/esp-hid-service-table/assets/213467/589c8a6e-8ba2-4419-84a7-7ddaaa60fb9f)

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -78,24 +78,28 @@ extern "C" void app_main(void) {
             static xb::InputReport report;
             static constexpr size_t report_size = sizeof(xb::InputReport);
             static uint8_t report_data[report_size];
-            static uint8_t battery_level = 0;
-            // toggle the up/down on the left joystick (axis_y, center is 32768, up is 65535, down is 0)
-            if (report.axis_y == 0) {
-              report.axis_y = 65534;
-            } else if (report.axis_y == 65534) {
-              report.axis_y = 0;
-            } else if (report.axis_y == 32767) {
-              report.axis_y = 0;
-            } else {
-              report.axis_y = 32767;
-            }
-            // toggle the 'b' button
+            static constexpr uint16_t AXIS_UP_VALUE = 65534;
+            static constexpr uint16_t AXIS_DOWN_VALUE = 0;
+            static constexpr uint16_t AXIS_CENTER_VALUE = 32767;
+            static bool go_up = true;
+            // toggle the 'b' button, which acts as the 'back' button on Android
             // report.btn_2 = !report.btn_2; // NOTE: disabling this because it's really annoying...
-            // copy the report into the report data
-            memcpy(report_data, &report, report_size);
-            // send an input report
-            hid_service_send_input_report(report_data, report_size);
+            // toggle the up/down on the left joystick (axis_y, center is 32768, up is 65535, down is 0)
+            if (go_up) {
+              report.axis_y = AXIS_UP_VALUE;
+              hid_service_send_input_report((const uint8_t*)&report, report_size);
+
+            } else {
+              report.axis_y = AXIS_DOWN_VALUE;
+              hid_service_send_input_report((const uint8_t*)&report, report_size);
+            }
+            // put it back to center
+            report.axis_y = AXIS_CENTER_VALUE;
+            hid_service_send_input_report((const uint8_t*)&report, report_size);
+            // toggle the direction
+            go_up = !go_up;
             // update the battery level
+            static uint8_t battery_level = 0;
             battery_level = (battery_level) % 100 + 5;
             hid_service_set_battery_level(battery_level);
           }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update the example so that per task execution the stick only moves one selection, then back to center to make it clearer that all inputs are going through and that it is simply ticking back and forth

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Makes it clearer that the example is properly ticking and all input reports that are being sent are making it through to the phone.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running on an QtPy ESP32-S3

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2023-10-06 at 16 06 58](https://github.com/finger563/esp-hid-service-table/assets/213467/589c8a6e-8ba2-4419-84a7-7ddaaa60fb9f)

https://github.com/finger563/esp-hid-service-table/assets/213467/f972932c-6285-44ac-a576-f49e8d22fc9b


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
