### PR TITLE
feat(ios): update hid service to work with iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ GATT Service Table APIs.
 
 https://github.com/finger563/esp-hid-service-table/assets/213467/f972932c-6285-44ac-a576-f49e8d22fc9b
 
+https://github.com/finger563/esp-hid-service-table/assets/213467/a30da3aa-47da-4cad-b3cb-7772f54a4562
+
 ## Implementation
 
 The way this example works is to create the following service tables in order:

--- a/components/hid_service/include/hid_service.hpp
+++ b/components/hid_service/include/hid_service.hpp
@@ -29,7 +29,9 @@
 #include "event_names.hpp"
 
 bool hid_service_is_connected();
-void hid_service_init();
+esp_bd_addr_t *hid_service_get_peer_address();
+void hid_service_init(std::string_view device_name_string_view);
+void hid_service_set_device_name(std::string_view device_name_string_view);
 void hid_service_set_report_descriptor(uint8_t* report_descriptor, size_t report_descriptor_len);
 void hid_service_send_input_report(const uint8_t* report, size_t report_len);
 void hid_service_set_battery_level(const uint8_t level);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -66,7 +66,7 @@ extern "C" void app_main(void) {
   }
 
   // initialize the hid service table
-  hid_service_init();
+  hid_service_init(CONFIG_DEVICE_NAME);
 
   // set the device plug and play ID (vendor ID, product ID, product version)
   uint16_t vendor_id = CONFIG_VENDOR_ID;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Save connected peer address
* Allow setting device name
* Update advertisement data to match what iOS expects
* When peer connects, set encryption
* Set authentication to LE_AUTH_BOND
* do not set ESP_BLE_SM_* configuration options

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We'd like this to work on both Android and iOS :)

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Running on QtPy ESP32s3 (BLE only) and testing with iPhone.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

https://github.com/finger563/esp-hid-service-table/assets/213467/a30da3aa-47da-4cad-b3cb-7772f54a4562

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
