### PR TITLE
fix(hid): fix hid service table characteristic permissions

### DIFF
--- a/components/hid_service/src/hid_service.cpp
+++ b/components/hid_service/src/hid_service.cpp
@@ -331,12 +331,12 @@ static void gatts_profile_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_
     logger.debug("                           handle: {}, value len: {}", param->write.handle, param->write.len);
     if (!param->write.is_prep){
       bool is_cfg_handle =
-        hid_handle_table[IDX_CHAR_CFG_HID_REPORT_XB] == param->write.handle;
+        hid_handle_table[IDX_CHAR_CFG_HID_REPORT] == param->write.handle;
 
       if (is_cfg_handle && param->write.len == 2){
         logger.debug("Configuration of {}",
-                     param->write.handle == hid_handle_table[IDX_CHAR_CFG_HID_REPORT_XB]
-                     ? "IDX_CHAR_CFG_HID_REPORT_XB"
+                     param->write.handle == hid_handle_table[IDX_CHAR_CFG_HID_REPORT]
+                     ? "IDX_CHAR_CFG_HID_REPORT"
                      : "UNKNOWN CFG HANDLE");
         uint16_t descr_value = param->write.value[1]<<8 | param->write.value[0];
         if (descr_value == 0x0001) {
@@ -394,9 +394,6 @@ static void gatts_profile_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_
 
     //start sent the update connection parameters to the peer device.
     esp_ble_gap_update_conn_params(&conn_params);
-
-    // set the encryption
-    esp_ble_set_encryption(param->connect.remote_bda, ESP_BLE_SEC_ENCRYPT_NO_MITM);
 
     // only if the device is bonded, send the report map
     if (is_bonded(param->connect.remote_bda)) {
@@ -560,7 +557,7 @@ void hid_service_set_report_descriptor(uint8_t* descriptor, size_t descriptor_le
 
 void hid_service_send_input_report(const uint8_t* report, size_t report_len) {
   logger.info("Sending input report of length {}", report_len);
-  send_indicate((uint8_t*)report, report_len, hid_handle_table[IDX_CHAR_VAL_HID_REPORT_XB]);
+  send_indicate((uint8_t*)report, report_len, hid_handle_table[IDX_CHAR_VAL_HID_REPORT]);
 }
 
 void hid_service_set_battery_level(const uint8_t level) {

--- a/components/hid_service_table/include/hid_service_table.hpp
+++ b/components/hid_service_table/include/hid_service_table.hpp
@@ -41,14 +41,9 @@ enum
     IDX_CHAR_VAL_HID_PROTOCOL_MODE,
 
     // HID Report characteristic, UUID: 0x2A4D, Properties: read, notify
-    IDX_CHAR_HID_REPORT_XB,
-    IDX_CHAR_VAL_HID_REPORT_XB,
-    IDX_CHAR_CFG_HID_REPORT_XB,
-    IDX_CHAR_REP_HID_REPORT_XB,
-
-    // HID Report characteristic, UUID: 0x2A4D, Properties: read, notify
     IDX_CHAR_HID_REPORT,
     IDX_CHAR_VAL_HID_REPORT,
+    IDX_CHAR_CFG_HID_REPORT,
     IDX_CHAR_REP_HID_REPORT,
 
     IDX_HID_NB,

--- a/components/hid_service_table/src/hid_service_table.cpp
+++ b/components/hid_service_table/src/hid_service_table.cpp
@@ -73,10 +73,6 @@ static const uint8_t hid_report_ref[] = {
   0x01, // report ID of the report that this reference refers to in the report descriptor
   0x01, // report type (1 = input, 2 = output, 3 = feature)
 };
-static const uint8_t hid_report_ref_feature[] = {
-  0x00, // report ID feature
-  0x03, // report type (1 = input, 2 = output, 3 = feature)
-};
 uint8_t *report_descriptor = NULL;
 size_t report_descriptor_len = 0;
 
@@ -123,7 +119,7 @@ const esp_gatts_attr_db_t hid_gatt_db[IDX_HID_NB] =
     {{ESP_GATT_AUTO_RSP}, {ESP_UUID_LEN_16, (uint8_t *)&character_declaration_uuid, ESP_GATT_PERM_READ,
                            CHAR_DECLARATION_SIZE, CHAR_DECLARATION_SIZE, (uint8_t *)&char_prop_read}},
     [IDX_CHAR_VAL_HID_REPORT_MAP]  =
-    {{ESP_GATT_AUTO_RSP}, {ESP_UUID_LEN_16, (uint8_t *)&GATTS_CHAR_UUID_HID_REPORT_MAP, ESP_GATT_PERM_READ,
+    {{ESP_GATT_AUTO_RSP}, {ESP_UUID_LEN_16, (uint8_t *)&GATTS_CHAR_UUID_HID_REPORT_MAP, ESP_GATT_PERM_READ | ESP_GATT_PERM_READ_ENCRYPTED,
                            HID_REPORT_MAP_MAX_LEN, sizeof(report_descriptor), (uint8_t *)&report_descriptor}},
     [IDX_CHAR_EXT_HID_REPORT_MAP]  =
     {{ESP_GATT_AUTO_RSP}, {ESP_UUID_LEN_16, (uint8_t *)&hid_report_map_ext_desc_uuid, ESP_GATT_PERM_READ,
@@ -139,31 +135,18 @@ const esp_gatts_attr_db_t hid_gatt_db[IDX_HID_NB] =
 
 
     /* Characteristic Declaration */
-    [IDX_CHAR_HID_REPORT_XB]      =
-    {{ESP_GATT_AUTO_RSP}, {ESP_UUID_LEN_16, (uint8_t *)&character_declaration_uuid, ESP_GATT_PERM_READ,
-                           CHAR_DECLARATION_SIZE, CHAR_DECLARATION_SIZE, (uint8_t *)&char_prop_read_notify}},
-    [IDX_CHAR_VAL_HID_REPORT_XB]  =
-    {{ESP_GATT_AUTO_RSP}, {ESP_UUID_LEN_16, (uint8_t *)&GATTS_CHAR_UUID_HID_REPORT, ESP_GATT_PERM_READ,
-                           HID_REPORT_MAX_LEN, 0, NULL}},
-    [IDX_CHAR_CFG_HID_REPORT_XB]  =
-    {{ESP_GATT_AUTO_RSP}, {ESP_UUID_LEN_16, (uint8_t *)&character_client_config_uuid, ESP_GATT_PERM_WRITE,
-                           sizeof(uint16_t), sizeof(notify_ccc), (uint8_t *)notify_ccc}},
-    [IDX_CHAR_REP_HID_REPORT_XB]  =
-    {{ESP_GATT_AUTO_RSP}, {ESP_UUID_LEN_16, (uint8_t *)&hid_report_ref_descr_uuid, ESP_GATT_PERM_READ,
-                           sizeof(hid_report_ref), sizeof(hid_report_ref), (uint8_t *)&hid_report_ref}},
-
-
-    /* Characteristic Declaration */
     [IDX_CHAR_HID_REPORT]      =
     {{ESP_GATT_AUTO_RSP}, {ESP_UUID_LEN_16, (uint8_t *)&character_declaration_uuid, ESP_GATT_PERM_READ,
-                           CHAR_DECLARATION_SIZE, CHAR_DECLARATION_SIZE, (uint8_t *)&char_prop_read_write}},
+                           CHAR_DECLARATION_SIZE, CHAR_DECLARATION_SIZE, (uint8_t *)&char_prop_read_notify}},
     [IDX_CHAR_VAL_HID_REPORT]  =
-    {{ESP_GATT_AUTO_RSP}, {ESP_UUID_LEN_16, (uint8_t *)&GATTS_CHAR_UUID_HID_REPORT, ESP_GATT_PERM_READ,
+    {{ESP_GATT_AUTO_RSP}, {ESP_UUID_LEN_16, (uint8_t *)&GATTS_CHAR_UUID_HID_REPORT, ESP_GATT_PERM_READ | ESP_GATT_PERM_READ_ENCRYPTED,
                            HID_REPORT_MAX_LEN, 0, NULL}},
+    [IDX_CHAR_CFG_HID_REPORT]  =
+    {{ESP_GATT_AUTO_RSP}, {ESP_UUID_LEN_16, (uint8_t *)&character_client_config_uuid, ESP_GATT_PERM_WRITE | ESP_GATT_PERM_WRITE_ENCRYPTED,
+                           sizeof(uint16_t), sizeof(notify_ccc), (uint8_t *)notify_ccc}},
     [IDX_CHAR_REP_HID_REPORT]  =
     {{ESP_GATT_AUTO_RSP}, {ESP_UUID_LEN_16, (uint8_t *)&hid_report_ref_descr_uuid, ESP_GATT_PERM_READ,
-                           sizeof(hid_report_ref_feature), sizeof(hid_report_ref_feature), (uint8_t *)hid_report_ref_feature}},
-
+                           sizeof(hid_report_ref), sizeof(hid_report_ref), (uint8_t *)&hid_report_ref}},
 
   };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Add encryption to report map and report
* Remove call to set security in connect event (since proper security automatically triggers pairing)
* Removed extra / unused feature report from hid service table.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There was a bug with the original implementation where iOS on first pair would not properly recognize the HID device and so it would not show as a game controller - you would have to manually disconnect then reconnect from the iOS BLE settings menu. 

This PR fixes that bug so that it works on first pair just fine :)

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running main on a QtPy ESP32 PICO and pairing and connecting to an iPhone 14.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
